### PR TITLE
Do not force static linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AM_PROG_LIBTOOL
 
 LT_INIT
 AM_INIT_AUTOMAKE
+AM_CONDITIONAL([STATIC_ENABLED], [test "$enable_static" != "no"])
 
 AC_CONFIG_FILES([src/Makefile Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,4 +11,7 @@ include_HEADERS = libdontpanic.h
 bin_PROGRAMS = dontpanic
 dontpanic_SOURCES = main.c
 dontpanic_LDADD   = libdontpanic.la
+
+if STATIC_ENABLED
 dontpanic_LDFLAGS = -static
+endif


### PR DESCRIPTION
If ./configure is run without options, dontpanic tool is linked statically
to the dontpanic library. If ./configure is invoked with --disable-static,
libtool will add RPATH pointing to a build-time directory into the
dontpanic tool. The path is obviously wrong after installing the files
into a final location (make install).

It's probably a bug in libtool. This patch fixes/work around it by not
enforcing dontpanic tool static linking inside the Makefile.am.

Signed-off-by: Petr Písař <ppisar@redhat.com>